### PR TITLE
2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/react-native-animated-fox",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A react-native version of https://github.com/MetaMask/metamask-logo",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is the release candidate for 2.1.0.

Changes since 2.0.1:

- #3 

This published the commit currently depended on through a git reference in `metamask-mobile`: https://github.com/MetaMask/metamask-mobile/blob/060ff000c44a865d72461363341fb633f6a3f5d8/package.json#L260